### PR TITLE
Update instruction to start integration tests

### DIFF
--- a/documentation/latest/dev/guide.md
+++ b/documentation/latest/dev/guide.md
@@ -79,8 +79,16 @@ export SERVER_IP=$(kubectl get nodes kind-control-plane -o json  |  jq -r '[.sta
 You can execute the integration tests by running the following command:
 
 ```bash
-SERVER_PORT=80 mvn verify -pl integration-tests -P integration-test -Dspring.profiles.active=dev
+WORKFLOW_SERVICE_PATH=/workflow-service \
+NOTIFICATION_SERVICE_PATH=/notification-service \
+NOTIFICATION_SERVER_PORT=8081 \
+SERVER_PORT=80 \
+mvn verify -pl integration-tests -P integration-test -Dspring.profiles.active=dev
 ```
+
+Please note that `WORKFLOW_SERVICE_PATH` and `NOTIFICATION_SERVICE_PATH` are
+the `Ingress` paths defined in [ingress.yaml](https://github.com/parodos-dev/parodos/blob/main/hack/manifests/testing/ingress.yaml).
+They ensure that the integration tests communicate with the correct services.
 
 ##### Update the cluster
 


### PR DESCRIPTION
After enabling notification service integration tests, it is necessary to specificy `workflow-service` and `notification-service` paths to execute the tests in a `Kind` cluster.

To do that, it is necessary to set two env vars: `WORKFLOW_SERVICE_PATH` and `NOTIFICATION_SERVICE_PATH`.