### PR TITLE
Add doc page for MTA

### DIFF
--- a/content/docs/workflows/escalation.md
+++ b/content/docs/workflows/escalation.md
@@ -1,6 +1,0 @@
----
-title: MTA (Migration Analysis for Applications)
-date: "2024-02-21"
----
-
-TODO - link with the future serverless-workflows/mta/README.md document. 

--- a/content/docs/workflows/m2k.md
+++ b/content/docs/workflows/m2k.md
@@ -3,4 +3,4 @@ title: serverless-workflows m2k
 date: "2024-02-27"
 ---
 
-{{< remoteMD "https://github.com/parodos-dev/serverless-workflows/blob/doc/m2k/move2kube/README.md?raw=true" >}}
+{{< remoteMD "https://github.com/parodos-dev/serverless-workflows/blob/main/move2kube/README.md?raw=true" >}}

--- a/content/docs/workflows/mta.md
+++ b/content/docs/workflows/mta.md
@@ -1,5 +1,5 @@
 ---
-title: serverless-workflows mta
+title: MTA analyis workflow
 date: "2024-02-29"
 ---
 

--- a/content/docs/workflows/mta.md
+++ b/content/docs/workflows/mta.md
@@ -1,0 +1,6 @@
+---
+title: serverless-workflows mta
+date: "2024-02-29"
+---
+
+{{< remoteMD "https://github.com/parodos-dev/serverless-workflows/blob/main/mta/README.md?raw=true" >}}


### PR DESCRIPTION
Now that https://github.com/parodos-dev/serverless-workflows/pull/120 is merged, we have docs for MTA, this PR add the doc to the website

This PR also fixes move2kube readme doc URL and remove useless escalation.md file