### PR TITLE
Arrange content by weight and with proper titles

### DIFF
--- a/content/docs/installation/_index.md
+++ b/content/docs/installation/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Installation"
+date: 2024-03-03
+weight: 1
+---
+
+The orchestrator solution is made of various independent components where each has its own
+installation method. At the moment we support a specialized helm chart to install everything
+from scratch on OpenShift or on Kubernetes. The installation is modular so if any of the pieces
+is already installed it can be made optional (more in the helm chart README.md below.
+

--- a/content/docs/installation/orchestrator-helm-chart.md
+++ b/content/docs/installation/orchestrator-helm-chart.md
@@ -1,5 +1,5 @@
 ---
-title: orchestrator-helm-chart README.md
+title: Orchestrator
 date: "2024-02-20"
 ---
 

--- a/content/docs/installation/serverless-workflows-helm.md
+++ b/content/docs/installation/serverless-workflows-helm.md
@@ -1,5 +1,5 @@
 ---
-title: serverless-workflows-helm README.md
+title: Workflows
 date: "2024-02-20"
 ---
 

--- a/content/docs/workflow-examples/_index.md
+++ b/content/docs/workflow-examples/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Serverless Workflow Examples"
+date: 2024-03-03
+weight: 3
+---
+
+Documentation of example workflows from https://github.com/parodos-dev/serverless-workflow-examples
+
+# How to add a new document
+Documents can include markdown content from all the related *`parodos-dev`* repositories. 
+To create a document entry from a markdown file use this:
+
+```bash
+./generate-doc-for-repo.sh \
+    https://github.com/parodos-dev/serverless-workflow-examples/blob/main/README.md > content/docs/workflow-examples/newdoc.md
+```

--- a/content/docs/workflow-examples/escalation/_index.md
+++ b/content/docs/workflow-examples/escalation/_index.md
@@ -1,4 +1,4 @@
 ---
-title: "Escalation Workflow Examples"
+title: "Escalation"
 date: 2024-02-28
 ---

--- a/content/docs/workflows/_index.md
+++ b/content/docs/workflows/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Serverless Workflows"
 date: 2024-02-20 
+weight: 2
 ---
 
 Documentation section of the project selected set of workflows.

--- a/content/docs/workflows/m2k.md
+++ b/content/docs/workflows/m2k.md
@@ -1,5 +1,5 @@
 ---
-title: serverless-workflows m2k
+title: move2kube
 date: "2024-02-27"
 ---
 

--- a/content/docs/workflows/serverless-workflows.md
+++ b/content/docs/workflows/serverless-workflows.md
@@ -1,6 +1,7 @@
 ---
-title: serverless-workflows README.md
+title: Develop
 date: "2024-02-20"
+weight: 100
 ---
 
 {{< remoteMD "https://github.com/parodos-dev/serverless-workflows/blob/main/README.md?raw=true" >}}


### PR DESCRIPTION
Now the content side bar looks like this:
```
Installation
    Orchestrator
    Workflows
Serverless-workflows
    Develop
    MTA analysis
    Move To Kube(m2k)
Serverless Workflows Examples
    Escalation
```
The order is set by 'weight' property in the front-matter.
Smaller values are 'lighter' i.e are at the top, like the
"Installation" section has weight: 1

Signed-off-by: Roy Golan <rgolan@redhat.com>
