### PR TITLE
Add references to orchestrator and workflow installations

### DIFF
--- a/content/docs/installation/_index.md
+++ b/content/docs/installation/_index.md
@@ -4,8 +4,9 @@ date: 2024-03-03
 weight: 1
 ---
 
-The orchestrator solution is made of various independent components where each has its own
-installation method. At the moment we support a specialized helm chart to install everything
-from scratch on OpenShift or on Kubernetes. The installation is modular so if any of the pieces
-is already installed it can be made optional (more in the helm chart README.md below.
+The deployment of the orchestrator involves multiple independent components, each with its unique installation process. Presently, our supported method is through a specialized Helm chart designed for deploying the orchestrator on either OpenShift or Kubernetes environments. This installation process is modular, allowing optional installation of components if they are already present.
+
+The *Orchestrator* deployment encompasses the installation of the engine for serving serverless workflows and Backstage, integrated with orchestrator plugins for workflow invocation, monitoring, and control.
+
+In addition to the *Orchestrator* deployment, we offer several *workflows* (linked below) that can be deployed using their respective installation methods.
 

--- a/content/docs/installation/orchestrator/_index.md
+++ b/content/docs/installation/orchestrator/_index.md
@@ -1,0 +1,12 @@
+---
+title: "Orchestrator"
+date: 2024-03-03
+---
+
+Installing the *Orchestartor* is facilitated through a Helm chart that is reponsible for installing all of the *Orchestrator* components.
+The *Orchestrator* is based on the [SonataFlow](https://sonataflow.org/serverlessworkflow/latest/index.html) and the [Serverless Workflow](https://serverlessworkflow.io/) technologies to design and manage the workflows.
+The *Orchestrator* plugins are deployed on [Janus IDP Backstage](https://github.com/janus-idp/backstage-showcase) instance, serves as the frontend.
+To utilize *Backstage* capabilities, the *Orchestartor* imports software templates designed to ease the development of new workflows and offers an opiniated method for managing their lifecycles by including CI/CD resources as part of the template.
+
+There are two options to install the Orchestrator deployment helm chart:
+

--- a/content/docs/installation/orchestrator/orchestrator-helm-chart.md
+++ b/content/docs/installation/orchestrator/orchestrator-helm-chart.md
@@ -1,5 +1,5 @@
 ---
-title: Orchestrator
+title: Deploy from source
 date: "2024-02-20"
 ---
 

--- a/content/docs/installation/orchestrator/orchestrator-helm-repository.md
+++ b/content/docs/installation/orchestrator/orchestrator-helm-repository.md
@@ -1,0 +1,6 @@
+---
+title: Deploy from Helm repository
+date: "2024-03-12"
+---
+
+{{< remoteMD "https://github.com/parodos-dev/orchestrator-helm-chart/blob/gh-pages/README.md?raw=true" >}}

--- a/content/docs/installation/serverless-workflows-helm.md
+++ b/content/docs/installation/serverless-workflows-helm.md
@@ -1,6 +1,0 @@
----
-title: Workflows
-date: "2024-02-20"
----
-
-{{< remoteMD "https://github.com/parodos-dev/serverless-workflows-helm/blob/main/README.md?raw=true" >}}

--- a/content/docs/installation/workflows/_index.md
+++ b/content/docs/installation/workflows/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Workflows"
+date: 2024-03-03
+---
+
+In addition to deploying the *Orchestrator*, we provide several preconfigured workflows that serve either as ready-to-use solutions or as starting points for customizing workflows according to the user's requirements. These workflows can be installed either through a Helm chart or by utilizing Kustomize.

--- a/content/docs/installation/workflows/serverless-workflows-helm.md
+++ b/content/docs/installation/workflows/serverless-workflows-helm.md
@@ -1,0 +1,6 @@
+---
+title: Helm
+date: "2024-02-20"
+---
+
+{{< remoteMD "https://github.com/parodos-dev/serverless-workflows-helm/blob/gh-pages/README.md?raw=true" >}}

--- a/content/docs/installation/workflows/serverless-workflows-kustomize.md
+++ b/content/docs/installation/workflows/serverless-workflows-kustomize.md
@@ -1,0 +1,6 @@
+---
+title: Kustomize
+date: "2024-02-20"
+---
+
+{{< remoteMD "https://github.com/parodos-dev/serverless-workflows-helm/blob/main/kustomize/README.md?raw=true" >}}


### PR DESCRIPTION
The PR splits the orchestrator installation section to install directly from sources or the helm repository.
For the workflows, the instructions are split between Helm and Kustomize.

![Selection_144](https://github.com/parodos-dev/parodos-dev.github.io/assets/316242/3069d417-4dfb-4129-b702-8364c67e2203)
