### PR TITLE
Add core concepts - workflow types

### DIFF
--- a/content/docs/core-concepts/_index.md
+++ b/content/docs/core-concepts/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Core Concepts"
+weight: 2
+---

--- a/content/docs/core-concepts/workflow-types/_index.md
+++ b/content/docs/core-concepts/workflow-types/_index.md
@@ -1,0 +1,75 @@
+---
+title: "Workflow Types"
+date: 2024-05-07
+---
+
+The *Orchestrator* features two primary workflow categories:
+- *Infrastructure workflows*: focus on automating infrastructure-related tasks
+- *Assessment workflows*: focus on evaluating and analyzing data to suggest suitable infrastructure workflow options for subsequent execution
+
+### Infrastructure workflow
+In Orchestration, an infrastructure refers to a workflow that executes a sequence of operations based on user input (optional) and generates output (optional) without requiring further action. 
+
+To define this type, developers need to include the following annotation in the workflow definition file:
+
+```yaml
+annotations:
+  - "workflow-type/infrastructure"
+```
+
+The Orchestrator plugin utilizes this metadata to facilitate the processing and visualization of infrastructure workflow inputs and outputs within the user interface.
+
+##### Examples:
+- [Greeting](https://github.com/parodos-dev/serverless-workflows/blob/main/greeting/greeting.sw.yaml)
+- [Ticket Escalation](https://github.com/parodos-dev/serverless-workflows/blob/main/escalation/ticketEscalation.sw.yaml)
+- [Move2Kube](https://github.com/parodos-dev/serverless-workflows/blob/main/move2kube/m2k.sw.yml)
+
+
+### Assessment workflow
+In Orchestration, an assessment is akin to an infrastructure workflow that concludes with a recommended course of action. 
+Upon completion, the assessment yields a *workflowOptions* object, which presents a list of infrastructure workflows suitable from the user's inputs evaluation. 
+
+To define this type, developers must include the following annotation in the workflow definition file:
+
+```yaml
+annotations:
+  - "workflow-type/assessment"
+```
+
+The Orchestrator plugin utilizes this metadata to facilitate the processing and visualization of assessment workflow inputs and outputs within the user interface. 
+This includes generating links to initiate infrastructure workflows from the list of recommended options, enabling seamless execution and integration.
+
+The *workflowOptions* object must possess six essential attributes with specific types, including lists that can be empty or contain objects with `id` and `name` properties, similar to the `currentVersion` attribute. See an example in the below code snippet.
+
+*It is the assessment workflow developer's responsibility to ensure that the provided workflow **id** in each workflowOptions attribute exists and is available in the environment.*
+
+```json
+{
+    "workflowOptions": {
+      "currentVersion": {
+        "id": "_AN_INFRASTRUCTURE_WORKFLOW_ID_",
+        "name": "_AN_INFRASTRUCTURE_WORKFLOW_NAME_"
+      },
+      "newOptions": [],
+      "otherOptions": [],
+      "upgradeOptions": [],
+      "migrationOptions": [
+        {
+            "id": "_ANOTHER_INFRASTRUCTURE_WORKFLOW_ID_",
+            "name": "_ANOTHER_INFRASTRUCTURE_WORKFLOW_NAME_"
+        }
+      ],
+      "continuationOptions": []
+    }
+}
+```
+
+##### Examples:
+- [MTA](https://github.com/parodos-dev/serverless-workflows/blob/main/mta/mta.sw.yaml)
+- [Dummy Assessment](https://github.com/parodos-dev/serverless-workflow-examples/tree/main/assessment)
+
+#### Note
+If the aforementioned annotation is missing in the workflow definition file, the *Orchestrator* plugin will default to treating the workflow as an infrastructure workflow, without considering its output.
+
+To avoid unexpected behavior and ensure clarity, it is strongly advised to always include the annotation to explicitly specify the workflow type, preventing any surprises or misinterpretations.
+

--- a/content/docs/core-concepts/workflow-types/_index.md
+++ b/content/docs/core-concepts/workflow-types/_index.md
@@ -8,7 +8,7 @@ The *Orchestrator* features two primary workflow categories:
 - *Assessment workflows*: focus on evaluating and analyzing data to suggest suitable infrastructure workflow options for subsequent execution
 
 ### Infrastructure workflow
-In Orchestration, an infrastructure refers to a workflow that executes a sequence of operations based on user input (optional) and generates output (optional) without requiring further action. 
+In the *Orchestrator*, an infrastructure refers to a workflow that executes a sequence of operations based on user input (optional) and generates output (optional) without requiring further action. 
 
 To define this type, developers need to include the following annotation in the workflow definition file:
 
@@ -17,7 +17,7 @@ annotations:
   - "workflow-type/infrastructure"
 ```
 
-The Orchestrator plugin utilizes this metadata to facilitate the processing and visualization of infrastructure workflow inputs and outputs within the user interface.
+The *Orchestrator* plugin utilizes this metadata to facilitate the processing and visualization of infrastructure workflow inputs and outputs within the user interface.
 
 ##### Examples:
 - [Greeting](https://github.com/parodos-dev/serverless-workflows/blob/main/greeting/greeting.sw.yaml)
@@ -26,7 +26,7 @@ The Orchestrator plugin utilizes this metadata to facilitate the processing and 
 
 
 ### Assessment workflow
-In Orchestration, an assessment is akin to an infrastructure workflow that concludes with a recommended course of action. 
+In the *Orchestrator*, an assessment is akin to an infrastructure workflow that concludes with a recommended course of action. 
 Upon completion, the assessment yields a *workflowOptions* object, which presents a list of infrastructure workflows suitable from the user's inputs evaluation. 
 
 To define this type, developers must include the following annotation in the workflow definition file:
@@ -36,7 +36,7 @@ annotations:
   - "workflow-type/assessment"
 ```
 
-The Orchestrator plugin utilizes this metadata to facilitate the processing and visualization of assessment workflow inputs and outputs within the user interface. 
+The *Orchestrator* plugin utilizes this metadata to facilitate the processing and visualization of assessment workflow inputs and outputs within the user interface. 
 This includes generating links to initiate infrastructure workflows from the list of recommended options, enabling seamless execution and integration.
 
 The *workflowOptions* object must possess six essential attributes with specific types, including lists that can be empty or contain objects with `id` and `name` properties, similar to the `currentVersion` attribute. See an example in the below code snippet.

--- a/content/docs/installation/_index.md
+++ b/content/docs/installation/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Installation"
 date: 2024-03-03
-weight: 2
+weight: 3
 ---
 
 The deployment of the orchestrator involves multiple independent components, each with its unique installation process. Presently, our supported method is through a specialized Helm chart designed for deploying the orchestrator on either OpenShift or Kubernetes environments. This installation process is modular, allowing optional installation of components if they are already present.

--- a/content/docs/plugins/_index.md
+++ b/content/docs/plugins/_index.md
@@ -1,5 +1,5 @@
 ---
 title: "Plugins"
 date: 2024-03-28
-Weight: 5
+Weight: 6
 ---

--- a/content/docs/serverless-workflow-examples/_index.md
+++ b/content/docs/serverless-workflow-examples/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Serverless Workflow Examples"
 date: 2024-03-03
-weight: 4
+weight: 5
 ---
 
 Documentation of example workflows from https://github.com/parodos-dev/serverless-workflow-examples

--- a/content/docs/serverless-workflows/_index.md
+++ b/content/docs/serverless-workflows/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Serverless Workflows"
 date: 2024-02-20 
-weight: 3
+weight: 4
 ---
 
 Documentation section of the project selected set of workflows.


### PR DESCRIPTION
This PR introduces a new 'Core Concepts' section to the documentation, which begins with a comprehensive explanation and examples of workflow types in the Orchestrator. This addition addresses a previously missing piece of documentation, aiming to provide essential guidance for developers creating assessment workflows from the Basic workflow bootstrap project. 

The output of this PR should look like:

<img width="1915" alt="Screenshot 2024-05-07 at 2 33 43 PM" src="https://github.com/parodos-dev/parodos-dev.github.io/assets/15964569/dfa7b469-afce-4bff-b5b3-f42c25c1dfb8">

<img width="1915" alt="Screenshot 2024-05-07 at 2 34 00 PM" src="https://github.com/parodos-dev/parodos-dev.github.io/assets/15964569/eb3d8f40-6446-49b5-bec9-998f6b1ce2e6">

<img width="1919" alt="Screenshot 2024-05-07 at 2 34 09 PM" src="https://github.com/parodos-dev/parodos-dev.github.io/assets/15964569/817f94c8-2d71-4a52-b37e-eb351c28e55a">
