### PR TITLE
FLPATH-1378: Typos in table of contents in docs

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -5,4 +5,4 @@ date: 2024-02-20
 
 # Parodos
 
-Choose a section from te list bellow. For Parodos introduction, check the [Quick Start](./quickstart/).
+Choose a section from the list below. For Parodos introduction, check the [Quick Start](./quickstart/).


### PR DESCRIPTION
Fixing typos in "Choose a section from te list bellow" to "Choose a section from the list below"