### PR TITLE
[FLTPATH-1386] Update installation documentation for OCP to use operator

### DIFF
--- a/content/1.2-rc/docs/installation/_index.md
+++ b/content/1.2-rc/docs/installation/_index.md
@@ -1,10 +1,10 @@
 ---
 title: "Installation"
-date: 2024-03-03
+date: 2024-09-10
 weight: 3
 ---
 
-The deployment of the orchestrator involves multiple independent components, each with its unique installation process. Presently, our supported method is through a specialized Helm chart designed for deploying the orchestrator on either OpenShift or Kubernetes environments. This installation process is modular, allowing optional installation of components if they are already present.
+The deployment of the orchestrator involves multiple independent components, each with its unique installation process. In an OpenShift Cluster, the Red Hat Catalog provides an operator that can handle the installation for you. This installation process is modular, as the CRD exposes various flags that allow you to control which components to install. For a vanilla Kubernetes, there is a helm chart that installs the orchestrator compoments.
 
 The *Orchestrator* deployment encompasses the installation of the engine for serving serverless workflows and Backstage, integrated with orchestrator plugins for workflow invocation, monitoring, and control.
 

--- a/content/1.2-rc/docs/installation/orchestrator.md
+++ b/content/1.2-rc/docs/installation/orchestrator.md
@@ -1,12 +1,12 @@
 ---
 title: "Orchestrator on OpenShift"
-date: 2024-03-03
+date: 2024-09-10
 ---
 
-Installing the *Orchestrator* is facilitated through a Helm chart that is responsible for installing all of the *Orchestrator* components.
+Installing the *Orchestrator* is facilitated through an operator available in the Red Hat Catalog in the OLM package. This operator is responsible for installing all of the *Orchestrator* components.
 The *Orchestrator* is based on the [SonataFlow](https://sonataflow.org/serverlessworkflow/latest/index.html) and the [Serverless Workflow](https://serverlessworkflow.io/) technologies to design and manage the workflows.
 The *Orchestrator* plugins are deployed on [Red Hat Developer Hub
 ](https://developers.redhat.com/rhdh/overview) instance, serves as the frontend.
 To utilize *Backstage* capabilities, the *Orchestrator* imports software templates designed to ease the development of new workflows and offers an opinionated method for managing their lifecycle by including CI/CD resources as part of the template.
 
-{{< remoteMD "https://github.com/parodos-dev/orchestrator-helm-chart/blob/gh-pages-stable-1.x/README.md?raw=true" >}}
+{{< remoteMD "https://github.com/parodos-dev/orchestrator-helm-operator/blob/gh-pages?raw=true" >}}


### PR DESCRIPTION
Changed installation instructions to reflect that for m2/1.2, in OpenShift the orchestrator is now installed using the operator and not the helm chart.