### PR TITLE
Copy referenced content to fix 1.2 documentation

### DIFF
--- a/content/1.2/docs/installation/orchestrator-k8s.md
+++ b/content/1.2/docs/installation/orchestrator-k8s.md
@@ -6,6 +6,7 @@ date: 2024-04-09
 The following guide is for installing on a Kubernetes cluster. It is well tested and working in CI with a [kind](https://kind.sigs.k8s.io/) installation.
 
 Here's a kind configuration that is easy to work with (the apiserver port is static, so the kubeconfig is always the same)
+
 ```yaml
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -15,14 +16,14 @@ networking:
 nodes:
   - role: control-plane
     kubeadmConfigPatches:
-    - |
-      kind: InitConfiguration
-      nodeRegistration:
-        kubeletExtraArgs:
-          node-labels: "ingress-ready=true"
-    - |
-      kind: KubeletConfiguration
-      localStorageCapacityIsolation: true
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+      - |
+        kind: KubeletConfiguration
+        localStorageCapacityIsolation: true
     extraPortMappings:
       - containerPort: 80
         hostPort: 9090
@@ -34,6 +35,7 @@ nodes:
 ```
 
 Save this file as `kind-config.yaml`, and now run:
+
 ```bash
 kind create cluster --config kind-config.yaml
 kubectl apply -f https://projectcontour.io/quickstart/contour.yaml
@@ -42,4 +44,80 @@ kubectl patch daemonsets -n projectcontour envoy -p '{"spec":{"template":{"spec"
 
 The cluster should be up and running with [Contour ingress-controller](https://projectcontour.io) installed, so localhost:9090 will direct the traffic to Backstage, because of the ingress created by the helm chart on port 80.
 
-{{< remoteMD "https://raw.githubusercontent.com/parodos-dev/orchestrator-helm-chart/main/charts/orchestrator-k8s/README.md" >}}
+# Orchestrator-k8s helm chart
+
+This chart will install the Orchestrator and all its dependencies on kubernetes.
+
+**THIS CHART IS NOT SUITED FOR PRODUCTION PURPOSES**, you should only use it for development or tests purposes
+
+The chart deploys:
+
+- RHDH-backstage https://github.com/redhat-developer/rhdh-chart
+- Serverless Workflows Operator (see sonata-serverless-operator.yaml)
+- knative serving
+- Knative eventing
+- Serverless Workflows (optional)
+
+### Usage
+
+```console
+helm repo add orchestrator https://parodos-dev.github.io/orchestrator-helm-chart
+
+helm install orchestrator orchestrator/orchestrator-k8s
+```
+
+## Configuration
+
+All of the backstage app-config is derived from the values.yaml.
+
+### Secrets as env vars:
+
+To use secret as env vars, like the one used for the notification, see charts/Orchestrator-k8s/templates/secret.yaml
+Every key in that secret will be available in the app-config for resolution.
+
+## Development
+
+```console
+git clone https://github.com/parodos-dev.github.io/orchestrator-helm-chart
+cd orchestrator-helm-chart/charts/orchestrator-k8s
+
+
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add backstage https://backstage.github.io/charts
+helm repo add postgresql-persistent https://sclorg.github.io/helm-charts
+helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
+helm repo add workflows https://parodos.dev/serverless-workflows-config
+
+helm dependencies build
+helm install orchestrator .
+```
+
+The output should look like that
+
+```console
+$ helm install orchestrator .
+Release "orchestrator" has been upgraded. Happy Helming!
+NAME: orchestrator
+LAST DEPLOYED: Tue Sep 19 18:19:07 2023
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+NOTES:
+This chart will install RHDH-backstage(RHDH upstream) + Serverless Workflows.
+
+To get RHDH's route location:
+    $ oc get route orchestrator-white-backstage -o jsonpath='https://{ .spec.host }{"\n"}'
+
+To get the serverless workflow operator status:
+    $ oc get deploy -n sonataflow-operator-system
+
+To get the serverless workflows status:
+    $ oc get sf
+
+```
+
+The chart notes will provide more information on:
+
+- route location of backstage
+- the sonata operator status
+- the sonata workflow deployed status

--- a/content/1.2/docs/installation/workflows/deploy-from-helm-repository.md
+++ b/content/1.2/docs/installation/workflows/deploy-from-helm-repository.md
@@ -3,4 +3,69 @@ title: Deploy From Helm Repository
 date: "2024-02-20"
 ---
 
-{{< remoteMD "https://github.com/parodos-dev/serverless-workflows-config/blob/gh-pages/docs/README.md?raw=true" >}}
+## Orchestrator Workflows Helm Repository
+
+This repository serves as a Helm chart repository for deploying serverless workflows with the Sonataflow Operator. It encompasses a collection of pre-defined workflows, each tailored to specific use cases. These workflows have undergone thorough testing and validation through Continuous Integration (CI) processes and are organized according to their chart versions.
+
+The repository includes a variety of serverless workflows, such as:
+
+- Greeting: A basic example workflow to demonstrate functionality.
+- Migration Toolkit for Application Analysis (MTA): This workflow evaluates applications to determine potential risks and the associated costs of containerizing the applications.
+- Move2Kube: Designed to facilitate the transition of an application to Kubernetes (K8s) environments.
+
+## Usage
+
+### Prerequisites
+
+To utilize the workflows contained in this repository, the Orchestrator Deployment must be installed on your OpenShift Container Platform (OCP) cluster. For detailed instructions on installing the Orchestrator, please visit the [Orchestrator Helm Based Operator Repository](https://www.parodos.dev/orchestrator-helm-operator/)
+
+## Installation
+
+```bash
+helm repo add orchestrator-workflows https://parodos.dev/serverless-workflows-config
+```
+
+View available workflows on the Helm repository:
+
+```
+helm search repo orchestrator-workflows
+```
+
+The expected result should look like (with different versions):
+
+```
+NAME                            	CHART VERSION	APP VERSION	DESCRIPTION
+orchestrator-workflows/greeting 	0.4.2        	1.16.0     	A Helm chart for the greeting serverless workflow
+orchestrator-workflows/move2kube	0.2.16       	1.16.0     	A Helm chart to deploy the move2kube workflow.
+orchestrator-workflows/mta      	0.2.16       	1.16.0     	A Helm chart for MTA serverless workflow
+orchestrator-workflows/workflows	0.2.24       	1.16.0     	A Helm chart for serverless workflows
+```
+
+You can install each workflow separately. For detailed information, please visit the page of each workflow:
+
+- [Greeting](https://github.com/parodos-dev/serverless-workflows-config/blob/gh-pages/docs/greeting/README.md)
+- [MTA](https://github.com/parodos-dev/serverless-workflows-config/blob/gh-pages/docs/mta/README.md)
+- [Move2Kube](https://github.com/parodos-dev/serverless-workflows-config/blob/gh-pages/docs/move2kube/README.md)
+
+## Installing workflows in additional namespaces
+
+When deploying a workflow in a namespace different from where Sonataflow services are running (e.g. sonataflow-infra), there are essential steps to follow. For detailed instructions, see the [Additional Workflow Namespaces section](https://github.com/parodos-dev/orchestrator-helm-operator/tree/main/docs/release-1.2?tab=readme-ov-file#additional-workflow-namespaces).
+
+## Version Compatability
+
+The workflows rely on components included in the [Orchestrator Operator](https://www.parodos.dev/orchestrator-helm-operator/). Therefore, it is crucial to match the workflow version with the corresponding Orchestrator version that supports it. The list below outlines the compatibility between the workflows and Orchestrator versions:
+| Workflows | Chart Version | Orchestrator Operator Version |
+|--------------------|---------------|----------------------|
+| mta-analysis | 0.3.x | 1.2.x |
+| move2kube | 0.3.x | 1.2.x |
+| create-ocp-project | 0.1.x | 1.2.x |
+| request-vm-cnv | 0.1.x | 1.2.x |
+| modify-vm-resources| 0.1.x | 1.2.x |
+| mta-v6 | 0.2.x | 1.2.x |
+| mta-v7 | 0.2.x | 1.2.x |
+| mtv-migration | 0.0.x | 1.2.x |
+| mtv-plan | 0.0.x | 1.2.x |
+
+## Helm index
+
+[https://www.parodos.dev/serverless-workflows-config/index.yaml](https://www.parodos.dev/serverless-workflows-config/index.yaml)

--- a/content/1.2/docs/installation/workflows/deploy-from-kustomize.md
+++ b/content/1.2/docs/installation/workflows/deploy-from-kustomize.md
@@ -3,4 +3,13 @@ title: Deploy From Kustomize
 date: "2024-02-20"
 ---
 
-{{< remoteMD "https://github.com/parodos-dev/serverless-workflows-config/blob/main/kustomize/README.md?raw=true" >}}
+# Deploy workflows by Kustomize
+
+The workflows can be deployed by Kustomize.
+
+Under each workflow folder, there is a README file with detailed instructions on how to install the workflow separately.
+
+- [Escalation](https://github.com/parodos-dev/serverless-workflows-config/blob/main/kustomize/escalation/README.md)
+- [Greeting](https://github.com/parodos-dev/serverless-workflows-config/blob/main/kustomize/greeting/README.md)
+- [Move2kube](https://github.com/parodos-dev/serverless-workflows-config/blob/main/kustomize/move2kube/README.md)
+- [MTA](https://github.com/parodos-dev/serverless-workflows-config/blob/main/kustomize/mta/README.md)

--- a/content/1.2/docs/plugins/orchestrator-plugin/_index.md
+++ b/content/1.2/docs/plugins/orchestrator-plugin/_index.md
@@ -3,4 +3,4 @@ title: Orchestrator Plugin
 date: "2024-04-03"
 ---
 
-{{< remoteMD "https://github.com/janus-idp/backstage-plugins/blob/main/plugins/orchestrator/README.md?raw=true" >}}
+{{< remoteMD "https://github.com/janus-idp/backstage-plugins/blob/1.2.x/plugins/orchestrator/README.md?raw=true" >}}

--- a/content/1.2/docs/serverless-workflows/assessment/mta-analysis.md
+++ b/content/1.2/docs/serverless-workflows/assessment/mta-analysis.md
@@ -3,4 +3,78 @@ title: MTA Analysis
 date: "2024-02-29"
 ---
 
-{{< remoteMD "https://github.com/parodos-dev/serverless-workflows/blob/main/mta/README.md?raw=true" >}}
+# MTA - migration analysis workflow
+
+# Synopsis
+
+This workflow is an assessment workflow type, that invokes an application analysis workflow using [MTA][1]
+and returns the [move2kube][3] workflow reference, to run next if the analysis is considered to be successful.
+
+Users are encouraged to use this workflow as self-service alternative for interacting with the MTA UI. Instead of running
+a mass-migration of project from a managed place, the project stakeholders can use this (or automation) to regularly check
+the cloud-readiness compatibility of their code.
+
+# Inputs
+
+- `repositoryUrl` [mandatory] - the git repo url to examine
+- `recipients` [mandatory] - A list of recipients for the notification in the format of `user:<namespace>/<username>` or `group:<namespace>/<groupname>`, i.e. `user:default/jsmith`.
+
+# Output
+
+1. On completion the workflow returns an [options structure][2] in the exit state of the workflow (also named variables in SonataFlow)
+   linking to the [move2kube][3] workflow that will generate k8s manifests for container deployment.
+1. When the workflow completes there should be a report link on the exit state of the workflow (also named variables in SonataFlow)
+   Currently this is working with MTA version 6.2.x and in the future 7.x version the report link will be removed or will be made
+   optional. Instead of an html report the workflow will use a machine friendly json file.
+
+# Dependencies
+
+- MTA version 6.2.x or Konveyor 0.2.x
+
+  - For OpenShift install MTA using the OperatorHub, search for MTA. Documentation is [here][1]
+  - For Kubernetes install Konveyor with olm
+    ```bash
+    kubectl create -f https://operatorhub.io/install/konveyor-0.2/konveyor-operator.yaml
+    ```
+
+# Runtime configuration
+
+| key                                                  | default                                                                                    | description                               |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------- |
+| mta.url                                              | http://mta-ui.openshift-mta.svc.cluster.local:8080                                         | Endpoint (with protocol and port) for MTA |
+| quarkus.rest-client.mta_json.url                     | ${mta.url}/hub                                                                             | MTA hub api                               |
+| quarkus.rest-client.notifications.url                | ${BACKSTAGE_NOTIFICATIONS_URL:http://backstage-backstage.rhdh-operator/api/notifications/} | Backstage notification url                |
+| quarkus.rest-client.mta_json.auth.basicAuth.username | username                                                                                   | Username for the MTA api                  |
+| quarkus.rest-client.mta_json.auth.basicAuth.password | password                                                                                   | Password for the MTA api                  |
+
+All the configuration items are on [./application.properties]
+
+# Testing
+
+User can test the MTA workflow by providing a git repository.
+
+#### Existing Repository
+
+An existing repository can be used. Alternatively, user can use example repo: [spring-petclinic][7]
+
+#### New Repository
+
+- Create a git repo with a simple Java class. It can either be public or private.
+  Currently, MTA supports mostly Java projects.
+- If repository is private, refer to [configuring repository][4] on how to set up credentials on MTA.
+  - Note: When creating the source control credentials in MTA (usually done by MTA admin), ensure to input personal access token in the password field.
+    Refer to [personal access token] [5] on how to create personal access token (classic) on GitHub.
+  - Also, git url address must use https. Refer to [about remote repositories][6] for more details.
+- If the repo is public, no further configuration is needed.
+
+# Workflow Diagram
+
+![mta workflow diagram](https://github.com/parodos-dev/serverless-workflows/blob/main/mta/mta.svg?raw=true)
+
+[1]: https://developers.redhat.com/products/mta/download
+[2]: https://github.com/parodos-dev/serverless-workflows/blob/main/assessment/schema/workflow-options-output-schema.json
+[3]: https://github.com/parodos-dev/serverless-workflows/tree/main/move2kube
+[4]: https://docs.redhat.com/en/documentation/migration_toolkit_for_applications/6.2/html-single/user_interface_guide/index#configuring-credentials
+[5]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic
+[6]: https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories
+[7]: https://github.com/spring-projects/spring-petclinic

--- a/content/1.2/docs/serverless-workflows/development.md
+++ b/content/1.2/docs/serverless-workflows/development.md
@@ -4,4 +4,61 @@ date: "2024-02-20"
 weight: 100
 ---
 
-{{< remoteMD "https://github.com/parodos-dev/serverless-workflows/blob/main/README.md?raw=true" >}}
+# Serverless-Workflows
+
+A selected set of serverless workflows.
+
+Here is the layout of directories per workflow. Each folder contains at least:
+
+- `application.properties` the configuration item specific for the workflow app itself.
+- `${workflow}.sw.yaml` the [serverless workflow definitions][1].
+- `specs/` optional folder with OpenAPI specs if the flow needs them.
+
+All .svg can be ignored, there's no real functional use for them in deployment
+and all of them are created by VSCode extension.
+
+Every workflow has a matching container image pushed to quay.io by a github workflows
+in the form of `quay.io/orchestrator/serverless-workflow-${workflow}`.
+
+## Current image statuses:
+
+- https://quay.io/repository/orchestrator/serverless-workflow-mta
+- https://quay.io/repository/orchestrator/serverless-workflow-m2k
+- https://quay.io/repository/orchestrator/serverless-workflow-greeting
+- https://quay.io/repository/orchestrator/serverless-workflow-escalation
+
+After image publishing, GitHub action will generate kubernetes manifests and push a PR to [the workflows helm chart repo][3]
+under a directory matching the workflow name. This repo is used to deploy the workflows to an environment
+with [Sonataflow operator][2] running.
+
+## How to introduce a new workflow
+
+Follow these steps to successfully add a new workflow:
+
+1. Create a folder under the root with the name of the flow, e.x `/onboarding`
+2. Copy `application.properties`, `onboarding.sw.yaml` into that folder
+3. Create a GitHub workflow file `.github/workflows/${workflow}.yaml` that will call `main` workflow (see greeting.yaml)
+4. Create a pull request but don't merge yet.
+5. Send a pull request to [serverless-workflows-config repository][3] to add a sub-chart
+   under the path `charts/workflows/charts/onboarding`. You can copy the greeting sub-chart directory and files.
+6. Create a PR to [serverless-workflows-config repository][3] and make sure its merge.
+7. Now the PR from 4 can be merged and an automatic PR will be created with the generated manifests. Review and merge.
+
+See [Continuous Integration with make](https://github.com/parodos-dev/serverless-workflows/blob/main/make.md) for implementation details of the CI pipeline.
+
+### Builder image
+
+There are two builder images under ./pipeline folder:
+
+- workflow-builder-dev.Dockerfile - references nightly build image from `docker.io/apache/incubator-kie-sonataflow-builder:main` that doesn't required any authorization
+- workflow-builder.Dockerfile - references OpenShift Serverless Logic builder image from registry.redhat.io which requires authorization.
+  - To use this dockerfile locally, you must be logged to registry.redhat.io. To get access to that registry, follow:
+    1. Get tokens [here](https://access.redhat.com/terms-based-registry/accounts). Once logged in to podman, you should be able to pull the image.
+    2. Verify pulling the image [here](https://catalog.redhat.com/software/containers/openshift-serverless-1-tech-preview/logic-swf-builder-rhel8/6483079349c48023fc262858?architecture=amd64&image=65e1a56104e00058ecdd52eb&container-tabs=gti)
+
+Note on CI:
+For every PR merged in the workflow directory, a GitHub Action runs an image build to generate manifests, and a new PR is automatically generated in the [serverless-workflows-config repository][3]. The credentials used by the build process are defined as organization level secret, and the content is from a token on the helm repo with an expiry period of 60 days. Currently only the repo owner (rgolangh) can recreate the token. This should be revised.
+
+[1]: https://github.com/serverlessworkflow/specification/tree/main?tab=readme-ov-file#documentation
+[2]: https://github.com/apache/incubator-kie-kogito-serverless-operator/
+[3]: https://github.com/parodos-dev/serverless-workflows-config

--- a/content/1.2/docs/serverless-workflows/infrastructure/move2kube.md
+++ b/content/1.2/docs/serverless-workflows/infrastructure/move2kube.md
@@ -3,4 +3,82 @@ title: Move2Kube
 date: "2024-02-27"
 ---
 
-{{< remoteMD "https://github.com/parodos-dev/serverless-workflows/blob/main/move2kube/README.md?raw=true" >}}
+Move2kube (m2k) workflow
+
+## Context
+
+This workflow is using https://move2kube.konveyor.io/ to migrate the existing code contained in a git repository to a K8s/OCP platform.
+
+Once the transformation is over, move2kube provides a zip file containing the transformed repo.
+
+### Design diagram
+
+![sequence_diagram.svg](https://raw.githubusercontent.com/parodos-dev/serverless-workflows/main/move2kube/sequence_diagram.jpg)
+![design.svg](https://raw.githubusercontent.com/parodos-dev/serverless-workflows/main/move2kube/design.svg)
+
+### Workflow
+
+![m2k.svg](https://raw.githubusercontent.com/parodos-dev/serverless-workflows/main/move2kube/m2k.svg)
+
+Note that if an error occurs during the migration planning there is no feedback given by the move2kube instance API. To overcome this, we defined a maximum amount of retries (`move2kube_get_plan_max_retries`) to execute while getting the planning before exiting with an error. By default the value is set to 10 and it can be overridden with the environment variable `MOVE2KUBE_GET_PLAN_MAX_RETRIES`.
+
+## Components
+
+The use case has the following components:
+
+1. `m2k`: the `Sonataflow` resource representing the workflow. A matching `Deployment` is created by the sonataflow operator..
+2. `m2k-save-transformation-func`: the Knative `Service` resource that holds the service retrieving the move2kube instance output and saving it to the git repository. A matching `Deployment` is created by the Knative deployment.
+3. `move2kube instance`: the `Deployment` running the move2kube instance
+4. Knative `Trigger`:
+   1. `m2k-save-transformation-event`: event sent by the `m2k` workflow that will trigger the execution of `m2k-save-transformation-func`.
+   2. `transformation-saved-trigger-m2k`: event sent by `m2k-save-transformation-func` if/once the move2kube output is successfully saved to the git repository.
+   3. `error-trigger-m2k`: event sent by `m2k-save-transformation-func` if an error while saving the move2kube output to the git repository.
+5. The Knative `Broker` named `default` which link the components together.
+
+## Usage
+
+1. Create a workspace and a project under it in your move2kube instance
+   - you can reach your move2kube instance by running
+   ```bash
+   oc -n sonataflow-infra get routes
+   ```
+   Sample output:
+   ```
+   NAME                                   HOST/PORT                                                                                             PATH   SERVICES                                 PORT    TERMINATION   WILDCARD
+   move2kube-route                        move2kube-route-sonataflow-infra.apps.cluster-c68jb.dynamic.redhatworkshops.io                               move2kube-svc                            <all>   edge          None
+   ```
+   - for more information, please refer to https://move2kube.konveyor.io/tutorials/ui
+2. Go to the backstage instance.
+
+To get it, you can run
+
+```bash
+oc -n rhdh-operator get routes
+```
+
+Sample output:
+
+```
+NAME                  HOST/PORT                                                                            PATH   SERVICES              PORT           TERMINATION     WILDCARD
+backstage-backstage   backstage-backstage-rhdh-operator.apps.cluster-c68jb.dynamic.redhatworkshops.io   /      backstage-backstage   http-backend   edge/Redirect   None
+```
+
+3. Go to the `Orchestrator` page.
+
+4. Click on `Move2Kube workflow` and then click the `run` button on the top right of the page.
+5. In the `repositoryURL` field, put the URL of your git project
+   - ie: https://bitbucket.org/parodos/m2k-test
+6. In the `sourceBranch` field, put the name of the branch holding the project you want to transform
+   - ie: `main`
+7. In the `targetBranch` field, put the name of the branch in which you want the move2kube output to be persisted. If the branch exists, the workflow will fail
+   - ie: `move2kube-output`
+8. In the `workspaceId` field, put the ID of the move2kube instance workspace to use for the transformation. Use the ID of the workspace created at the 1st step.
+   - ie: `a46b802d-511c-4097-a5cb-76c892b48d71`
+9. In the `projectId` field, put the ID of the move2kube instance project under the previous workspace to use for the transformation. Use the ID of the project created at the 1st step.
+   - ie: `9c7f8914-0b63-4985-8696-d46c17ba4ebe`
+10. Then click on `nextStep`
+11. Click on `run` to trigger the execution
+12. Once a new transformation has started and is waiting for your input, you will receive a notification with a link to the Q&A
+    - For more information about what to expect and how to answer the Q&A, please visit [the official move2kube documentation](https://move2kube.konveyor.io/tutorials/ui)
+13. Once you completed the Q&A, the process will continue and the output of the transformation will be saved in your git repository, you will receive a notification to inform you of the completion of the workflow.
+    - You can now clone the repository and checkout the output branch to deploy your manifests to your cluster! You can check [the move2kube documention](https://move2kube.konveyor.io/tutorials/cli#deploying-the-application-to-kubernetes-with-the-generated-artifacts) if you need guidance on how to deploy the generated artifacts.

--- a/content/1.2/docs/serverless-workflows/infrastructure/simple-escalation.md
+++ b/content/1.2/docs/serverless-workflows/infrastructure/simple-escalation.md
@@ -3,4 +3,54 @@ title: Simple Escalation
 date: "2024-02-28"
 ---
 
-{{< remoteMD "https://github.com/parodos-dev/serverless-workflows/blob/main/escalation/README.md?raw=true" >}}
+# Simple escalation workflow
+
+An escalation workflow integrated with Atlassian JIRA using [SonataFlow](https://sonataflow.org/serverlessworkflow/latest/index.html).
+
+## Prerequisite
+
+- Access to a Jira server (URL, user and [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/))
+- Access to an OpenShift cluster with `admin` Role
+
+## Workflow diagram
+
+![Escalation workflow diagram](https://github.com/parodos-dev/serverless-workflows/blob/main/escalation/ticketEscalation.svg?raw=true)
+
+**Note**:
+The value of the `.jiraIssue.fields.status.statusCategory.key` field is the one to be used to identify when the `done` status is reached, all the other
+similar fields are subject to translation to the configured language and cannot be used for a consistent check.
+
+## Application configuration
+
+Application properties can be initialized from environment variables before running the application:
+
+| Environment variable         | Description                                                                                              | Mandatory | Default value |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------- | --------- | ------------- |
+| `JIRA_URL`                   | The Jira server URL                                                                                      | ✅        |               |
+| `JIRA_USERNAME`              | The Jira server username                                                                                 | ✅        |               |
+| `JIRA_API_TOKEN`             | The Jira API Token                                                                                       | ✅        |               |
+| `JIRA_PROJECT`               | The key of the Jira project where the escalation issue is created                                        | ❌        | `TEST`        |
+| `JIRA_ISSUE_TYPE`            | The ID of the Jira issue type to be created                                                              | ✅        |               |
+| `OCP_API_SERVER_URL`         | The OpensShift API Server URL                                                                            | ✅        |               |
+| `OCP_API_SERVER_TOKEN`       | The OpensShift API Server Token                                                                          | ✅        |               |
+| `ESCALATION_TIMEOUT_SECONDS` | The number of seconds to wait before triggering the escalation request, after the issue has been created | ❌        | `60`          |
+| `POLLING_PERIODICITY`(1)     | The polling periodicity of the issue state checker, according to ISO 8601 duration format                | ❌        | `PT6S`        |
+
+(1) This is still hardcoded as `PT5S` while waiting for a fix to [KOGITO-9811](https://issues.redhat.com/browse/KOGITO-9811)
+
+## How to run
+
+```bash
+mvn clean quarkus:dev
+```
+
+Example of POST to trigger the flow (see input schema in [ocp-onboarding-schema.json](./src/main/resources/ocp-onboarding-schema.json)):
+
+```bash
+curl -XPOST -H "Content-Type: application/json" http://localhost:8080/ticket-escalation -d '{"namespace": "_YOUR_NAMESPACE_"}'
+```
+
+Tips:
+
+- Visit [Workflow Instances](http://localhost:8080/q/dev/org.kie.kogito.kogito-quarkus-serverless-workflow-devui/workflowInstances)
+- Visit (Data Index Query Service)[http://localhost:8080/q/graphql-ui/]


### PR DESCRIPTION
Issue: The 1.2 documentation is referencing "main" branches of external projects.

Unless we can branch-out those projects for 1.2, we need to make a copy of the content to lock the changes. Otherwise, ongoing development would make this 1.2 documentation unmatching with the 1.2 features.

The "main" documentation is untouched - keeps referencing those external document. When time of 1.3 comes, we can either copy actual referenced content or branch-out those external projects and update links in this project.