### PR TITLE
Remove kustomize from doc as not supported anymore

### DIFF
--- a/content/main/docs/installation/workflows/_index.md
+++ b/content/main/docs/installation/workflows/_index.md
@@ -3,4 +3,4 @@ title: "Workflows"
 date: 2024-03-03
 ---
 
-In addition to deploying the Orchestrator, we provide several preconfigured workflows that serve either as ready-to-use solutions or as starting points for customizing workflows according to the user's requirements. These workflows can be installed either through a Helm chart or by utilizing Kustomize.
+In addition to deploying the Orchestrator, we provide several preconfigured workflows that serve either as ready-to-use solutions or as starting points for customizing workflows according to the user's requirements. These workflows can be installed through a Helm chart.

--- a/content/main/docs/installation/workflows/deploy-from-kustomize.md
+++ b/content/main/docs/installation/workflows/deploy-from-kustomize.md
@@ -1,6 +1,0 @@
----
-title: Deploy From Kustomize
-date: "2024-02-20"
----
-
-{{< remoteMD "https://github.com/parodos-dev/serverless-workflows-config/blob/main/kustomize/README.md?raw=true" >}}


### PR DESCRIPTION
Closes [FLPATH-1731](https://issues.redhat.com/browse/FLPATH-1731)
Remove kustomize from doc as not supported anymore

Related to https://github.com/parodos-dev/serverless-workflows-config/pull/784